### PR TITLE
New Connected event in NamedPipeClient and minor changes

### DIFF
--- a/NamedPipeWrapper/NamedPipeClient.cs
+++ b/NamedPipeWrapper/NamedPipeClient.cs
@@ -16,7 +16,7 @@ namespace NamedPipeWrapper
     public class NamedPipeClient<TReadWrite> : NamedPipeClient<TReadWrite, TReadWrite> where TReadWrite : class
     {
         /// <summary>
-        /// Constructs a new <c>NamedPipeClient</c> to connect to the <see cref="NamedPipeNamedPipeServer{TReadWrite}"/> specified by <paramref name="pipeName"/>.
+        /// Constructs a new <c>NamedPipeClient</c> to connect to the <see cref="NamedPipeServer{TReadWrite}"/> specified by <paramref name="pipeName"/>.
         /// </summary>
         /// <param name="pipeName">Name of the server's pipe</param>
         /// <param name="serverName">server name default is local.</param>
@@ -69,7 +69,7 @@ namespace NamedPipeWrapper
         private string _serverName { get; set; }
 
         /// <summary>
-        /// Constructs a new <c>NamedPipeClient</c> to connect to the <see cref="NamedPipeServer{TRead, TWrite}"/> specified by <paramref name="pipeName"/>.
+        /// Constructs a new <c>NamedPipeClient</c> to connect to the <see cref="NamedPipeServer{TReadWrite}"/> specified by <paramref name="pipeName"/>.
         /// </summary>
         /// <param name="pipeName">Name of the server's pipe</param>
         /// <param name="serverName">the Name of the server, default is  local machine</param>
@@ -113,35 +113,62 @@ namespace NamedPipeWrapper
         }
 
         #region Wait for connection/disconnection
-
-        public void WaitForConnection()
+        /// <summary>
+        /// Wait for connection
+        /// </summary>
+        /// <returns>true if connected</returns>
+        public bool WaitForConnection()
         {
-            _connected.WaitOne();
+            return _connected.WaitOne();
         }
 
-        public void WaitForConnection(int millisecondsTimeout)
+        /// <summary>
+        /// Wait for connection
+        /// </summary>
+        /// <param name="millisecondsTimeout"></param>
+        /// <returns>true if connected</returns>
+        public bool WaitForConnection(int millisecondsTimeout)
         {
-            _connected.WaitOne(millisecondsTimeout);
+            return _connected.WaitOne(millisecondsTimeout);
         }
 
-        public void WaitForConnection(TimeSpan timeout)
+        /// <summary>
+        /// Wait for connection
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns>true if connected</returns>
+        public bool WaitForConnection(TimeSpan timeout)
         {
-            _connected.WaitOne(timeout);
+            return _connected.WaitOne(timeout);
         }
 
-        public void WaitForDisconnection()
+        /// <summary>
+        /// Wait for disconnection
+        /// </summary>
+        /// <returns>true if disconnected</returns>
+        public bool WaitForDisconnection()
         {
-            _disconnected.WaitOne();
+            return _disconnected.WaitOne();
         }
 
-        public void WaitForDisconnection(int millisecondsTimeout)
+        /// <summary>
+        /// Wait for disconnection
+        /// </summary>
+        /// <param name="millisecondsTimeout"></param>
+        /// <returns>true if disconnected</returns>
+        public bool WaitForDisconnection(int millisecondsTimeout)
         {
-            _disconnected.WaitOne(millisecondsTimeout);
+            return _disconnected.WaitOne(millisecondsTimeout);
         }
 
-        public void WaitForDisconnection(TimeSpan timeout)
+        /// <summary>
+        /// Wait for disconnection
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns>true if disconnected</returns>
+        public bool WaitForDisconnection(TimeSpan timeout)
         {
-            _disconnected.WaitOne(timeout);
+            return _disconnected.WaitOne(timeout);
         }
 
         #endregion

--- a/NamedPipeWrapper/NamedPipeConnection.cs
+++ b/NamedPipeWrapper/NamedPipeConnection.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO.Pipes;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Threading;
 using NamedPipeWrapper.IO;
 using NamedPipeWrapper.Threading;

--- a/NamedPipeWrapper/NamedPipeServer.cs
+++ b/NamedPipeWrapper/NamedPipeServer.cs
@@ -25,6 +25,7 @@ namespace NamedPipeWrapper
         /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
         /// </summary>
         /// <param name="pipeName">Name of the pipe to listen on</param>
+        /// <param name="pipeSecurity"></param>
         public NamedPipeServer(string pipeName, PipeSecurity pipeSecurity)
             : base(pipeName, pipeSecurity)
         {
@@ -67,12 +68,12 @@ namespace NamedPipeWrapper
         private int _nextPipeId;
 
         private volatile bool _shouldKeepRunning;
-        private volatile bool _isRunning;
 
         /// <summary>
         /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
         /// </summary>
         /// <param name="pipeName">Name of the pipe to listen on</param>
+        /// <param name="pipeSecurity"></param>
         public Server(string pipeName, PipeSecurity pipeSecurity)
         {
             _pipeName = pipeName;
@@ -153,12 +154,10 @@ namespace NamedPipeWrapper
 
         private void ListenSync()
         {
-            _isRunning = true;
             while (_shouldKeepRunning)
             {
                 WaitForConnection(_pipeName, _pipeSecurity);
             }
-            _isRunning = false;
         }
 
         private void WaitForConnection(string pipeName, PipeSecurity pipeSecurity)

--- a/UnitTests/SerializableTests.cs
+++ b/UnitTests/SerializableTests.cs
@@ -35,7 +35,6 @@ namespace UnitTests
         private int _expectedHash;
         private TestCollection _actualData;
         private int _actualHash;
-        private bool _clientDisconnected;
 
         private DateTime _startTime;
 
@@ -60,7 +59,6 @@ namespace UnitTests
             _expectedHash = 0;
             _actualData = null;
             _actualHash = 0;
-            _clientDisconnected = false;
 
             _server.ClientMessage += ServerOnClientMessage;
 


### PR DESCRIPTION
To solve issue #7 i have created the event Connected in NamedPipeClient.
Now it's possible to call PushMessage in Connected event handler without using WaitForConnection.
Use instead a blocking collection in Connected and Error event handlers.
Minor changes:  WaitForConnection and WaitForDisconnection methods return WaitOne result.