### PR TITLE
Add serialization extensibility point

### DIFF
--- a/NamedPipeWrapper/IO/Serialization/BinaryFormatterSerializer.cs
+++ b/NamedPipeWrapper/IO/Serialization/BinaryFormatterSerializer.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace NamedPipeWrapper.IO.Serialization
+{
+	internal class BinaryFormatterSerializer : ISerializer
+	{
+		private readonly BinaryFormatter _binaryFormatter = new BinaryFormatter();
+
+		public T Deserialize<T>(byte[] data) where T : class
+		{
+			using (var memoryStream = new MemoryStream(data))
+			{
+				return (T)_binaryFormatter.Deserialize(memoryStream);
+			}
+		}
+
+		public byte[] Serialize<T>(T value) where T : class
+		{
+			using (var memoryStream = new MemoryStream())
+			{
+				_binaryFormatter.Serialize(memoryStream, value);
+				return memoryStream.ToArray();
+			}
+		}
+	}
+}

--- a/NamedPipeWrapper/IO/Serialization/ExtensibilityPoint.cs
+++ b/NamedPipeWrapper/IO/Serialization/ExtensibilityPoint.cs
@@ -1,0 +1,9 @@
+﻿namespace NamedPipeWrapper.IO.Serialization
+{
+	public static class ExtensibilityPoint
+	{
+		public delegate ISerializer CreateSerializerDelegate();
+
+		public static CreateSerializerDelegate CreateSerializer = () => new BinaryFormatterSerializer();
+	}
+}

--- a/NamedPipeWrapper/IO/Serialization/ISerializer.cs
+++ b/NamedPipeWrapper/IO/Serialization/ISerializer.cs
@@ -1,0 +1,9 @@
+﻿namespace NamedPipeWrapper.IO.Serialization
+{
+	public interface ISerializer
+	{
+		T Deserialize<T>(byte[] data) where T : class;
+
+		byte[] Serialize<T>(T value) where T : class;
+	}
+}

--- a/NamedPipeWrapper/NamedPipeWrapper.csproj
+++ b/NamedPipeWrapper/NamedPipeWrapper.csproj
@@ -36,6 +36,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IO\Serialization\BinaryFormatterSerializer.cs" />
+    <Compile Include="IO\Serialization\ExtensibilityPoint.cs" />
+    <Compile Include="IO\Serialization\ISerializer.cs" />
     <Compile Include="NamedPipeClient.cs" />
     <Compile Include="NamedPipeConnection.cs" />
     <Compile Include="IO\PipeStreamReader.cs" />


### PR DESCRIPTION
Changes allows to override default serialization alghoritm with libraries like protobuf-net or ZeroFormatter that are faster than BinaryFormatter.
It's simple:
ExtensibilityPoint.CreateSerializer = ()=> { return mplementation of ISerialization interface. }